### PR TITLE
Fix @formium/client 'module' path in package.json

### DIFF
--- a/.changeset/silent-onions-bathe.md
+++ b/.changeset/silent-onions-bathe.md
@@ -1,0 +1,6 @@
+---
+"@formium/cli": patch
+"@formium/client": patch
+---
+
+Fix @formium/client 'module' path in package.json

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,7 +16,7 @@
     "prepublish": "npm run build"
   },
   "main": "dist/index.js",
-  "module": "dist/client.esm.js",
+  "module": "dist/formium.esm.js",
   "typings": "dist/index.d.ts",
   "files": [
     "README.md",


### PR DESCRIPTION
https://unpkg.com/browse/@formium/client@0.1.3/dist/

Fixes the "module" path in the package.json

I assume this is related to the tsdx `--name Formium` flag for tsdx causing it to be named this, which I didn't want to change.